### PR TITLE
Add Content-length to response

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -74,9 +74,9 @@ def captcha_image(request, key):
     image.save(out, "PNG")
     out.seek(0)
 
-    response = HttpResponse()
-    response['Content-Type'] = 'image/png'
+    response = HttpResponse(mimetype='image/png')
     response.write(out.read())
+    response['Content-length'] = out.tell()
 
     return response
 


### PR DESCRIPTION
I'm using ajax for django forms.
Therefore i need to load new captcha with ajax.
example django view:

``` python
def process_form(request):
    #some form processing code
    challenge, response = settings.get_challenge()()
    store = CaptchaStore.objects.create(challenge=challenge, response=response)
    key = store.hashkey
    image_url = reverse('captcha-image', kwargs=dict(key=key))
    return HttpResponse(json.dumps( {'key':key, 'url':image_url} ), mimetype="application/json")
```

When i did try this code:

``` javascript
//ajax request to get_new_captcha
$('img.captcha').attr('src',url);
```

Firebug log example: http://img42.imageshack.us/img42/5092/93527288.png

Sometime response size returned incorrect. And image not displayed.
With my fix everything work fine.
