### PR TITLE
fix for "AccessInit: hash collision: 3 for both 1 and 1" exceptions

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -9,12 +9,11 @@ import re
 import tempfile
 
 try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
     import Image
     import ImageDraw
     import ImageFont
-except ImportError:
-    from PIL import Image, ImageDraw, ImageFont
-
 
 NON_DIGITS_RX = re.compile('[^\d]')
 


### PR DESCRIPTION
This gets rid of "AccessInit: hash collision: 3 for both 1 and 1" exceptions that may happen on some PIL installations. See e.g. http://jaredforsyth.com/blog/2010/apr/28/accessinit-hash-collision-3-both-1-and-1/ for an explanation.
