### PR TITLE
replace os.popen with subprocess.call in captcha_audio

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -7,6 +7,7 @@ import os
 import random
 import re
 import tempfile
+import subprocess
 
 try:
     import Image
@@ -90,8 +91,7 @@ def captcha_audio(request, key):
         else:
             text = ', '.join(list(text))
         path = str(os.path.join(tempfile.gettempdir(), '%s.wav' % key))
-        cline = '%s -t "%s" -o "%s"' % (settings.CAPTCHA_FLITE_PATH, text, path)
-        os.popen(cline).read()
+        subprocess.call([settings.CAPTCHA_FLITE_PATH, "-t", text, "-o", path])
         if os.path.isfile(path):
             response = HttpResponse()
             f = open(path, 'rb')


### PR DESCRIPTION
Hello,

we tried to use apparmor to secure our Django web and we found out that shell (/bin/sh) is executed by your app when flite is run. This is a side effect of using the now deprecated os.popen to run the command and is quite inconvenient when you try to secure the application.
In the attached patch, I replaced it with a subprocess.call function which has the benefit of not starting shell and also taking care of proper argument escaping.

Best regards

Beda
