### PR TITLE
id_for_label outputs wrong id for prefixed forms

### DIFF
--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -51,7 +51,9 @@ class CaptchaTextInput(MultiWidget):
 
     # This probably needs some more love
     def id_for_label(self, id_):
-        return 'id_captcha_1'
+        if id_:
+            id_ += '_1'
+        return id_
 
 
 class CaptchaField(MultiValueField):


### PR DESCRIPTION
Django supports prefixes for forms:

https://docs.djangoproject.com/en/1.4/ref/forms/api/#prefixes-for-forms

When the captcha form is prefixed, the id_for_label returned is wrong.
