### PR TITLE
various fixes

### DIFF
--- a/captcha/conf/settings.py
+++ b/captcha/conf/settings.py
@@ -1,4 +1,4 @@
-import os
+﻿import os
 from django.conf import settings
 
 CAPTCHA_FONT_PATH = getattr(settings, 'CAPTCHA_FONT_PATH', os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'fonts/Vera.ttf')))
@@ -43,10 +43,10 @@ def get_challenge():
 def noise_functions():
     if CAPTCHA_NOISE_FUNCTIONS:
         return map(_callable_from_string, CAPTCHA_NOISE_FUNCTIONS)
-    return list()
+    return []
 
 
 def filter_functions():
     if CAPTCHA_FILTER_FUNCTIONS:
         return map(_callable_from_string, CAPTCHA_FILTER_FUNCTIONS)
-    return list()
+    return []

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -1,57 +1,93 @@
-from captcha.conf import settings
+﻿from captcha.conf import settings
+from django.conf import settings as django_settings
 from captcha.models import CaptchaStore, get_safe_now
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse,  NoReverseMatch
 from django.forms import ValidationError
 from django.forms.fields import CharField, MultiValueField
 from django.forms.widgets import TextInput, MultiWidget, HiddenInput
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 
 
-class CaptchaTextInput(MultiWidget):
-    def __init__(self, attrs=None, **kwargs):
-        self._args = kwargs
+class BaseCaptchaTextInput(MultiWidget):
+    """
+    Base class for Captcha widgets
+    """
+    def __init__(self, attrs=None):
         widgets = (
             HiddenInput(attrs),
             TextInput(attrs),
         )
-        self._args['output_format'] = self._args.get('output_format') or settings.CAPTCHA_OUTPUT_FORMAT
-
-        for key in ('image', 'hidden_field', 'text_field'):
-            if '%%(%s)s' % key not in self._args['output_format']:
-                raise ImproperlyConfigured('All of %s must be present in your CAPTCHA_OUTPUT_FORMAT setting. Could not find %s' % (
-                    ', '.join(['%%(%s)s' % k for k in ('image', 'hidden_field', 'text_field')]),
-                    '%%(%s)s' % key
-                ))
-        super(CaptchaTextInput, self).__init__(widgets, attrs)
+        super(BaseCaptchaTextInput, self).__init__(widgets, attrs)
 
     def decompress(self, value):
         if value:
             return value.split(',')
         return [None, None]
 
-    def format_output(self, rendered_widgets):
-        hidden_field, text_field = rendered_widgets
-        return self._args['output_format'] % dict(image=self.image_and_audio, hidden_field=hidden_field, text_field=text_field)
+    def fetch_captcha_store(self, name, value, attrs=None):
+        """
+        Fetches a new CaptchaStore
+        This has to be called inside render
+        """
+        if django_settings.DEBUG:
+            try:
+                reverse('captcha-image', args=('dummy',))
+            except NoReverseMatch:
+                raise ImproperlyConfigured('Make sure you\'ve included captcha.urls as explained in the INSTALLATION section on http://readthedocs.org/docs/django-simple-captcha/en/latest/usage.html#installation')
+
+        key = CaptchaStore.generate_key()
+
+        # these can be used by format_output and render
+        self._value = [key, u'']
+        self._key = key
+        self.id_ = self.build_attrs(attrs).get('id', None)
 
     def render(self, name, value, attrs=None):
-        try:
-            reverse('captcha-image', args=('dummy',))
-        except NoReverseMatch:
-            raise ImproperlyConfigured('Make sure you\'ve included captcha.urls as explained in the INSTALLATION section on http://readthedocs.org/docs/django-simple-captcha/en/latest/usage.html#installation')
+        self.fetch_captcha_store(name, value, attrs)
+        return super(BaseCaptchaTextInput, self).render(name, self._value, attrs=attrs)
 
-        # store = CaptchaStore()
-        key = CaptchaStore.generate_key()
-        value = [key, u'']
-
-        self.image_and_audio = '<img src="%s" alt="captcha" class="captcha" />' % reverse('captcha-image', kwargs=dict(key=key))
-        if settings.CAPTCHA_FLITE_PATH:
-            self.image_and_audio = '<a href="%s" title="%s">%s</a>' % (reverse('captcha-audio', kwargs=dict(key=key)), str(_('Play CAPTCHA as audio file')), self.image_and_audio)
-        return super(CaptchaTextInput, self).render(name, value, attrs=attrs)
-
-    # This probably needs some more love
     def id_for_label(self, id_):
-        return 'id_captcha_1'
+        return id_ + '_1'
+
+    def image_url(self):
+        return reverse('captcha-image', kwargs={'key' : self._key})
+
+    def audio_url(self):
+        return reverse('captcha-audio', kwargs={'key' : self._key}) if settings.CAPTCHA_FLITE_PATH else None
+
+    def refresh_url(self):
+        return reverse('captcha-refresh')
+
+class CaptchaTextInput(BaseCaptchaTextInput):
+    def __init__(self, attrs=None, **kwargs):
+        self._args = kwargs
+        self._args['output_format'] = self._args.get('output_format') or settings.CAPTCHA_OUTPUT_FORMAT
+        if django_settings.DEBUG:
+            for key in ('image', 'hidden_field', 'text_field'):
+                if '%%(%s)s' % key not in self._args['output_format']:
+                    raise ImproperlyConfigured('All of %s must be present in your CAPTCHA_OUTPUT_FORMAT setting. Could not find %s' % (
+                        ', '.join(['%%(%s)s' % k for k in ('image', 'hidden_field', 'text_field')]),
+                        '%%(%s)s' % key
+                    ))
+        super(CaptchaTextInput, self).__init__(attrs)
+
+    def format_output(self, rendered_widgets):
+        hidden_field, text_field = rendered_widgets
+        return self._args['output_format'] % {
+            'image' : self.image_and_audio,
+            'hidden_field' : hidden_field,
+            'text_field'  : text_field
+        }
+
+    def render(self, name, value, attrs=None):
+        self.fetch_captcha_store(name, value, attrs)
+
+        self.image_and_audio = '<img src="%s" alt="captcha" class="captcha" />' % self.image_url()
+        if settings.CAPTCHA_FLITE_PATH:
+            self.image_and_audio = '<a href="%s" title="%s">%s</a>' % (self.audio_url(), str(_('Play CAPTCHA as audio file')), self.image_and_audio)
+
+        return super(CaptchaTextInput, self).render(name, self._value, attrs=attrs)
 
 
 class CaptchaField(MultiValueField):
@@ -62,12 +98,12 @@ class CaptchaField(MultiValueField):
         )
         if 'error_messages' not in kwargs or 'invalid' not in kwargs.get('error_messages'):
             if 'error_messages' not in kwargs:
-                kwargs['error_messages'] = dict()
-            kwargs['error_messages'].update(dict(invalid=_('Invalid CAPTCHA')))
+                kwargs['error_messages'] = {}
+            kwargs['error_messages'].update({'invalid' : _('Invalid CAPTCHA')})
 
-        widget = kwargs.pop('widget', None) or CaptchaTextInput(output_format=kwargs.pop('output_format', None))
+        kwargs['widget'] = kwargs.pop('widget', CaptchaTextInput(output_format=kwargs.pop('output_format', None)))
 
-        super(CaptchaField, self).__init__(fields=fields, widget=widget, *args, **kwargs)
+        super(CaptchaField, self).__init__(fields, *args, **kwargs)
 
     def compress(self, data_list):
         if data_list:
@@ -83,12 +119,12 @@ class CaptchaField(MultiValueField):
             try:
                 # try to delete the captcha based on its hash
                 CaptchaStore.objects.get(hashkey=value[0]).delete()
-            except Exception:
+            except CaptchaStore.DoesNotExist:
                 # ignore errors
                 pass
         else:
             try:
                 CaptchaStore.objects.get(response=response, hashkey=value[0], expiration__gt=get_safe_now()).delete()
-            except Exception:
-                raise ValidationError(getattr(self, 'error_messages', dict()).get('invalid', _('Invalid CAPTCHA')))
+            except CaptchaStore.DoesNotExist:
+                raise ValidationError(getattr(self, 'error_messages', {}).get('invalid', _('Invalid CAPTCHA')))
         return value

--- a/captcha/tests/__init__.py
+++ b/captcha/tests/__init__.py
@@ -1,7 +1,8 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 from captcha.conf import settings
 from captcha.fields import CaptchaField, CaptchaTextInput
 from captcha.models import CaptchaStore, get_safe_now
+from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -147,12 +148,16 @@ class CaptchaCase(TestCase):
         self.assertTrue('<p>Hello, captcha world</p>' in str(r.content))
 
     def testInvalidOutputFormat(self):
+        # we turn on DEBUG because CAPTCHA_OUTPUT_FORMAT is only checked debug
+        old_debug= django_settings.DEBUG
+        django_settings.DEBUG = True
         settings.CAPTCHA_OUTPUT_FORMAT = u'%(image)s'
         try:
             self.client.get(reverse('captcha-test'))
             self.fail()
         except ImproperlyConfigured as e:
             self.assertTrue('CAPTCHA_OUTPUT_FORMAT' in str(e))
+        django_settings.DEBUG = old_debug
 
     def testPerFormFormat(self):
         settings.CAPTCHA_OUTPUT_FORMAT = u'%(image)s testCustomFormatString %(hidden_field)s %(text_field)s'

--- a/captcha/views.py
+++ b/captcha/views.py
@@ -1,4 +1,4 @@
-from captcha.conf import settings
+﻿from captcha.conf import settings
 from captcha.helpers import captcha_image_url
 from captcha.models import CaptchaStore
 from django.http import HttpResponse, Http404
@@ -110,12 +110,12 @@ def captcha_audio(request, key):
 
 def captcha_refresh(request):
     """  Return json with new captcha for ajax refresh request """
-    if request.is_ajax():
-        to_json_responce = dict()
+    if not request.is_ajax():
+        raise Http404
 
-        new_key = CaptchaStore.generate_key()
-        to_json_responce['key'] = new_key
-        to_json_responce['image_url'] = captcha_image_url(new_key)
-
-        return HttpResponse(json.dumps(to_json_responce), content_type='application/json')
-    raise Http404
+    new_key  = CaptchaStore.generate_key()
+    to_json_response = {
+        'key' : new_key,
+        'image_url' : captcha_image_url(new_key),
+    }
+    return HttpResponse(json.dumps(to_json_response), content_type='application/json')


### PR DESCRIPTION
This is basically the subset of backward-compatible changes of [PC 34](https://github.com/mbi/django-simple-captcha/pull/34). On my environments, all the tests are passing (notice that I had to amend the test of `testInvalidOutputFormat`).
- add a base class for captcha widgets to allow easier extensions
- catch `CaptchaStore.DoesNotExist` instead of the broad `Exception` in `CaptchaField.clean()`
- use `[]` and `{}` instead of `list()` and `dict()` [[1]](http://stackoverflow.com/questions/6610606/dict-literal-vs-dict-constructor-any-preferred)
- check `output_format` and `reverse('captcha-image', args=('dummy',))` only in `DEBUG` mode
- use `ugettext` instead of `ugettext_lazy` in `fields.py`
