### PR TITLE
Added CAPTCHA_IMAGE_SIZE option

### DIFF
--- a/captcha/conf/settings.py
+++ b/captcha/conf/settings.py
@@ -17,6 +17,8 @@ CAPTCHA_LENGTH = int(getattr(settings, 'CAPTCHA_LENGTH', 4))  # Chars
 CAPTCHA_IMAGE_BEFORE_FIELD = getattr(settings, 'CAPTCHA_IMAGE_BEFORE_FIELD', True)
 CAPTCHA_DICTIONARY_MIN_LENGTH = getattr(settings, 'CAPTCHA_DICTIONARY_MIN_LENGTH', 0)
 CAPTCHA_DICTIONARY_MAX_LENGTH = getattr(settings, 'CAPTCHA_DICTIONARY_MAX_LENGTH', 99)
+CAPTCHA_IMAGE_SIZE = getattr(settings, 'CAPTCHA_IMAGE_SIZE', None)
+
 if CAPTCHA_IMAGE_BEFORE_FIELD:
     CAPTCHA_OUTPUT_FORMAT = getattr(settings, 'CAPTCHA_OUTPUT_FORMAT', '%(image)s %(hidden_field)s %(text_field)s')
 else:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -22,6 +22,13 @@ Font-size in pixels of the rendered text.
 
 Defaults to '22'.
 
+CAPTCHA_IMAGE_SIZE
+-----------------
+
+Image size in pixels of generated captcha, specified by 2-tuple (width, height)
+
+Defaults to `None` (automatically calculated)
+
 CAPTCHA_LETTER_ROTATION
 -----------------------
 


### PR DESCRIPTION
Provide ability to force image size
Useful when by design there is a need of some specific size so that we dont have to do image scaling with css or try to calculate some value for scale variable

Usage is like that

CAPTCHA_IMAGE_SIZE = (100, 50)

![download](https://cloud.githubusercontent.com/assets/1760399/6666864/42f1ab60-cbf9-11e4-8dc1-6faa7c6f5454.png)