### PR TITLE
Chaged URLs to avoid deprecations in django 2.0

### DIFF
--- a/captcha/urls.py
+++ b/captcha/urls.py
@@ -1,12 +1,13 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
-urlpatterns = patterns(
-    'captcha.views',
-    url(r'image/(?P<key>\w+)/$', 'captcha_image', name='captcha-image', kwargs={'scale': 1}),
-    url(r'image/(?P<key>\w+)@2/$', 'captcha_image', name='captcha-image-2x', kwargs={'scale': 2}),
-    url(r'audio/(?P<key>\w+)/$', 'captcha_audio', name='captcha-audio'),
-    url(r'refresh/$', 'captcha_refresh', name='captcha-refresh'),
-)
+from captcha import views
+
+urlpatterns = [
+    url(r'image/(?P<key>\w+)/$', views.captcha_image, name='captcha-image', kwargs={'scale': 1}),
+    url(r'image/(?P<key>\w+)@2/$', views.captcha_image, name='captcha-image-2x', kwargs={'scale': 2}),
+    url(r'audio/(?P<key>\w+)/$', views.captcha_audio, name='captcha-audio'),
+    url(r'refresh/$', views.captcha_refresh, name='captcha-refresh'),
+]


### PR DESCRIPTION
Changed urlpatterns to be a list of url instances due to deprecations timeline for version 2.0
Changed url views to be the functions due to deprecation in using strings as views

Change should be retrocompatible with version 1.4+, but not tested in 1.4 version. Tested in 1.8+ and development version