### PR TITLE
Session store

### DIFF
--- a/captcha/backends/base.py
+++ b/captcha/backends/base.py
@@ -1,0 +1,26 @@
+from captcha.conf import settings as captcha_settings
+
+class DoesNotExist(Exception):
+    """ Can't find captcha in store """
+    pass
+
+class BaseStore(object):
+    DoesNotExist = DoesNotExist
+
+    def generate_key(self):
+        """
+        Generate captcha with unique key
+        """
+        return captcha_settings.get_challenge()()
+        
+    def remove_expired(self):
+        """
+        Remove expired captcha records
+        """
+        pass
+
+    def get(self, response=None, hashkey=None, allow_expired = True):
+        """
+        Get captcha from store, or rise exception if captcha wasn't found
+        """
+        pass

--- a/captcha/backends/base.py
+++ b/captcha/backends/base.py
@@ -1,8 +1,10 @@
 from captcha.conf import settings as captcha_settings
 
+
 class DoesNotExist(Exception):
     """ Can't find captcha in store """
     pass
+
 
 class BaseStore(object):
     DoesNotExist = DoesNotExist
@@ -12,14 +14,14 @@ class BaseStore(object):
         Generate captcha with unique key
         """
         return captcha_settings.get_challenge()()
-        
+
     def remove_expired(self):
         """
         Remove expired captcha records
         """
         pass
 
-    def get(self, response=None, hashkey=None, allow_expired = True):
+    def get(self, response=None, hashkey=None, allow_expired=True):
         """
         Get captcha from store, or rise exception if captcha wasn't found
         """

--- a/captcha/backends/db.py
+++ b/captcha/backends/db.py
@@ -1,13 +1,13 @@
-from captcha.conf import settings as captcha_settings
 from ..models import CaptchaStore, get_safe_now
 from .base import BaseStore
 
+
 class DBStore(BaseStore):
-    def __init__(self, key = None):
+    def __init__(self, key=None):
         self._captcha = {}
         if key:
             try:
-                cap = CaptchaStore.objects.get(hashkey = key)
+                cap = CaptchaStore.objects.get(hashkey=key)
                 self._captcha = {
                     'hashkey': cap.hashkey,
                     'challenge': cap.challenge,
@@ -16,23 +16,23 @@ class DBStore(BaseStore):
                 }
             except CaptchaStore.DoesNotExist:
                 raise self.DoesNotExist
-        
+
     def __getitem__(self, key):
         return self._captcha[key]
-        
+
     def remove_expired(self):
         CaptchaStore.objects.filter(expiration__lte=get_safe_now()).delete()
 
     def generate_key(self):
         return CaptchaStore.generate_key()
 
-    def get(self, response=None, hashkey=None, allow_expired = True):
+    def get(self, response=None, hashkey=None, allow_expired=True):
         store = DBStore(hashkey)
         if response and store['response'] != response:
             raise self.DoesNotExist
         if not allow_expired and store['expiration'] < get_safe_now():
             raise self.DoesNotExist
         return store
-        
+
     def delete(self):
-        CaptchaStore.objects.filter(hashkey = self['hashkey']).delete()
+        CaptchaStore.objects.filter(hashkey=self['hashkey']).delete()

--- a/captcha/backends/db.py
+++ b/captcha/backends/db.py
@@ -1,0 +1,38 @@
+from captcha.conf import settings as captcha_settings
+from ..models import CaptchaStore, get_safe_now
+from .base import BaseStore
+
+class DBStore(BaseStore):
+    def __init__(self, key = None):
+        self._captcha = {}
+        if key:
+            try:
+                cap = CaptchaStore.objects.get(hashkey = key)
+                self._captcha = {
+                    'hashkey': cap.hashkey,
+                    'challenge': cap.challenge,
+                    'response': cap.response,
+                    'expiration': cap.expiration,
+                }
+            except CaptchaStore.DoesNotExist:
+                raise self.DoesNotExist
+        
+    def __getitem__(self, key):
+        return self._captcha[key]
+        
+    def remove_expired(self):
+        CaptchaStore.objects.filter(expiration__lte=get_safe_now()).delete()
+
+    def generate_key(self):
+        return CaptchaStore.generate_key()
+
+    def get(self, response=None, hashkey=None, allow_expired = True):
+        store = DBStore(hashkey)
+        if response and store['response'] != response:
+            raise self.DoesNotExist
+        if not allow_expired and store['expiration'] < get_safe_now():
+            raise self.DoesNotExist
+        return store
+        
+    def delete(self):
+        CaptchaStore.objects.filter(hashkey = self['hashkey']).delete()

--- a/captcha/backends/session.py
+++ b/captcha/backends/session.py
@@ -3,6 +3,7 @@ from captcha.conf import settings as captcha_settings
 from django.conf import settings
 from importlib import import_module
 Store = import_module(settings.SESSION_ENGINE).SessionStore
+import django
     
 class SessionStore(BaseStore):
 
@@ -16,7 +17,8 @@ class SessionStore(BaseStore):
         return store.session_key
         
     def remove_expired(self):
-        Store.clear_expired()
+        if not django.get_version() < '1.5':
+            Store.clear_expired()
 
     def get(self, response=None, hashkey=None, allow_expired = True):
         s = Store(session_key=hashkey)

--- a/captcha/backends/session.py
+++ b/captcha/backends/session.py
@@ -1,27 +1,35 @@
 from .base import BaseStore
 from captcha.conf import settings as captcha_settings
 from django.conf import settings
-from importlib import import_module
-Store = import_module(settings.SESSION_ENGINE).SessionStore
 import django
-    
+try:
+    from importlib import import_module
+    Store = import_module(settings.SESSION_ENGINE).SessionStore
+except:
+    # py 2.6
+    backend = __import__(settings.SESSION_ENGINE, globals(), locals(), ['SessionStore'], -1)
+    Store = backend.SessionStore
+
+
 class SessionStore(BaseStore):
 
     def generate_key(self):
         challenge, response = super(SessionStore, self).generate_key()
         store = Store()
         store.set_expiry(60 * int(captcha_settings.CAPTCHA_TIMEOUT))
-        store['challenge']=challenge
-        store['response']=response
+        store['challenge'] = challenge
+        store['response'] = response
         store.save()
         return store.session_key
-        
+
     def remove_expired(self):
         if not django.get_version() < '1.5':
             Store.clear_expired()
 
-    def get(self, response=None, hashkey=None, allow_expired = True):
+    def get(self, response=None, hashkey=None, allow_expired=True):
         s = Store(session_key=hashkey)
+        if not s.get('response'):
+            raise self.DoesNotExist
         if response:
             if s['response'] != response:
                 raise self.DoesNotExist

--- a/captcha/backends/session.py
+++ b/captcha/backends/session.py
@@ -1,0 +1,28 @@
+from .base import BaseStore
+from captcha.conf import settings as captcha_settings
+from django.conf import settings
+from importlib import import_module
+Store = import_module(settings.SESSION_ENGINE).SessionStore
+    
+class SessionStore(BaseStore):
+
+    def generate_key(self):
+        challenge, response = super(SessionStore, self).generate_key()
+        store = Store()
+        store.set_expiry(60 * int(captcha_settings.CAPTCHA_TIMEOUT))
+        store['challenge']=challenge
+        store['response']=response
+        store.save()
+        return store.session_key
+        
+    def remove_expired(self):
+        Store.clear_expired()
+
+    def get(self, response=None, hashkey=None, allow_expired = True):
+        s = Store(session_key=hashkey)
+        if response:
+            if s['response'] != response:
+                raise self.DoesNotExist
+            if not allow_expired and s.get_expiry_age() < 0:
+                raise self.DoesNotExist
+        return s

--- a/captcha/conf/settings.py
+++ b/captcha/conf/settings.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 from django.conf import settings
 
 CAPTCHA_FONT_PATH = getattr(settings, 'CAPTCHA_FONT_PATH', os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'fonts/Vera.ttf')))
@@ -18,6 +18,7 @@ CAPTCHA_IMAGE_BEFORE_FIELD = getattr(settings, 'CAPTCHA_IMAGE_BEFORE_FIELD', Tru
 CAPTCHA_DICTIONARY_MIN_LENGTH = getattr(settings, 'CAPTCHA_DICTIONARY_MIN_LENGTH', 0)
 CAPTCHA_DICTIONARY_MAX_LENGTH = getattr(settings, 'CAPTCHA_DICTIONARY_MAX_LENGTH', 99)
 CAPTCHA_IMAGE_SIZE = getattr(settings, 'CAPTCHA_IMAGE_SIZE', None)
+CAPTCHA_STORE = getattr(settings, 'CAPTCHA_STORE', 'DB')
 
 if CAPTCHA_IMAGE_BEFORE_FIELD:
     CAPTCHA_OUTPUT_FORMAT = getattr(settings, 'CAPTCHA_OUTPUT_FORMAT', '%(image)s %(hidden_field)s %(text_field)s')

--- a/captcha/management/commands/captcha_clean.py
+++ b/captcha/management/commands/captcha_clean.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 from captcha.models import get_safe_now
+from captcha.conf import settings
 import sys
 
 
@@ -7,19 +8,27 @@ class Command(BaseCommand):
     help = "Clean up expired captcha hashkeys."
 
     def handle(self, **options):
-        from captcha.models import CaptchaStore
-        verbose = int(options.get('verbosity'))
-        expired_keys = CaptchaStore.objects.filter(expiration__lte=get_safe_now()).count()
-        if verbose >= 1:
-            print("Currently %d expired hashkeys" % expired_keys)
-        try:
-            CaptchaStore.remove_expired()
-        except:
+        if settings.CAPTCHA_STORE == 'SESSION':
+            from ...backends.session import SessionStore
+            try:
+                SessionStore().remove_expired()
+                print("Expired sessions removed.")
+            except:
+                print("Unable to delete expired sessions.")
+        elif settings.CAPTCHA_STORE == 'DB':
+            from captcha.models import CaptchaStore
+            verbose = int(options.get('verbosity'))
+            expired_keys = CaptchaStore.objects.filter(expiration__lte=get_safe_now()).count()
             if verbose >= 1:
-                print("Unable to delete expired hashkeys.")
-            sys.exit(1)
-        if verbose >= 1:
-            if expired_keys > 0:
-                print("%d expired hashkeys removed." % expired_keys)
-            else:
-                print("No keys to remove.")
+                print("Currently %d expired hashkeys" % expired_keys)
+            try:
+                CaptchaStore.remove_expired()
+            except:
+                if verbose >= 1:
+                    print("Unable to delete expired hashkeys.")
+                sys.exit(1)
+            if verbose >= 1:
+                if expired_keys > 0:
+                    print("%d expired hashkeys removed." % expired_keys)
+                else:
+                    print("No keys to remove.")

--- a/captcha/models.py
+++ b/captcha/models.py
@@ -26,38 +26,38 @@ def get_safe_now():
         pass
     return datetime.datetime.now()
 
+if captcha_settings.CAPTCHA_STORE == "DB":
+    class CaptchaStore(models.Model):
+        challenge = models.CharField(blank=False, max_length=32)
+        response = models.CharField(blank=False, max_length=32)
+        hashkey = models.CharField(blank=False, max_length=40, unique=True)
+        expiration = models.DateTimeField(blank=False)
 
-class CaptchaStore(models.Model):
-    challenge = models.CharField(blank=False, max_length=32)
-    response = models.CharField(blank=False, max_length=32)
-    hashkey = models.CharField(blank=False, max_length=40, unique=True)
-    expiration = models.DateTimeField(blank=False)
+        def save(self, *args, **kwargs):
+            self.response = self.response.lower()
+            if not self.expiration:
+                self.expiration = get_safe_now() + datetime.timedelta(minutes=int(captcha_settings.CAPTCHA_TIMEOUT))
+            if not self.hashkey:
+                key_ = (
+                    smart_text(randrange(0, MAX_RANDOM_KEY)) +
+                    smart_text(time.time()) +
+                    smart_text(self.challenge, errors='ignore') +
+                    smart_text(self.response, errors='ignore')
+                ).encode('utf8')
+                self.hashkey = hashlib.sha1(key_).hexdigest()
+                del(key_)
+            super(CaptchaStore, self).save(*args, **kwargs)
 
-    def save(self, *args, **kwargs):
-        self.response = self.response.lower()
-        if not self.expiration:
-            self.expiration = get_safe_now() + datetime.timedelta(minutes=int(captcha_settings.CAPTCHA_TIMEOUT))
-        if not self.hashkey:
-            key_ = (
-                smart_text(randrange(0, MAX_RANDOM_KEY)) +
-                smart_text(time.time()) +
-                smart_text(self.challenge, errors='ignore') +
-                smart_text(self.response, errors='ignore')
-            ).encode('utf8')
-            self.hashkey = hashlib.sha1(key_).hexdigest()
-            del(key_)
-        super(CaptchaStore, self).save(*args, **kwargs)
+        def __unicode__(self):
+            return self.challenge
 
-    def __unicode__(self):
-        return self.challenge
+        def remove_expired(cls):
+            cls.objects.filter(expiration__lte=get_safe_now()).delete()
+        remove_expired = classmethod(remove_expired)
 
-    def remove_expired(cls):
-        cls.objects.filter(expiration__lte=get_safe_now()).delete()
-    remove_expired = classmethod(remove_expired)
+        @classmethod
+        def generate_key(cls):
+            challenge, response = captcha_settings.get_challenge()()
+            store = cls.objects.create(challenge=challenge, response=response)
 
-    @classmethod
-    def generate_key(cls):
-        challenge, response = captcha_settings.get_challenge()()
-        store = cls.objects.create(challenge=challenge, response=response)
-
-        return store.hashkey
+            return store.hashkey

--- a/captcha/views.py
+++ b/captcha/views.py
@@ -1,6 +1,7 @@
 from captcha.conf import settings
 from captcha.helpers import captcha_image_url
 from django.http import HttpResponse, Http404
+from django.core.exceptions import ImproperlyConfigured
 import random
 import re
 import tempfile
@@ -39,6 +40,7 @@ elif settings.CAPTCHA_STORE == 'DB':
     CaptchaStore = DBStore()
 else:
     raise ImproperlyConfigured
+
 
 def getsize(font, text):
     if hasattr(font, 'getoffset'):

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -33,7 +33,7 @@ INSTALLED_APPS = [
     'captcha',
 ]
 
-LANGUAGE_CODE = "en"
+LANGUAGE_CODE = "en-us"
 
 LANGUAGES = (
     ('en', 'English'),


### PR DESCRIPTION
CAPTCHA_STORE setting added.

CAPTCHA_STORE = 'DB' (default). Captcha info stored in CaptchaStore model (same as before).
 CAPTCHA_STORE = 'SESSION'. Captcha info stored in SessionStore (sessions should be enabled).

Known issue: django will made new migration after changing CAPTCHA_STORE setting and running makemigrations.

upd: django 1.4 compatible.
