### PR TITLE
Simplify `get_safe_now`

### DIFF
--- a/captcha/models.py
+++ b/captcha/models.py
@@ -1,6 +1,5 @@
 from captcha.conf import settings as captcha_settings
 from django.db import models
-from django.conf import settings
 from django.utils.encoding import smart_text
 import datetime
 import random
@@ -19,12 +18,11 @@ MAX_RANDOM_KEY = 18446744073709551616     # 2 << 63
 
 def get_safe_now():
     try:
-        from django.utils.timezone import utc
-        if settings.USE_TZ:
-            return datetime.datetime.utcnow().replace(tzinfo=utc)
-    except:
-        pass
-    return datetime.datetime.now()
+        from django.utils import timezone
+    except ImportError:
+        # Django < 1.4
+        return datetime.datetime.now()
+    return timezone.now()
 
 
 class CaptchaStore(models.Model):


### PR DESCRIPTION
This change is simplifying `get_safe_now` by not repeating Django's logic

Preserve compatiblity with Django 1.3 (I don't know if it is needed)