### PR TITLE
Remove non-ascii characters from beginning of settings/fields

### DIFF
--- a/captcha/conf/settings.py
+++ b/captcha/conf/settings.py
@@ -1,4 +1,4 @@
-﻿import os
+import os
 from django.conf import settings
 
 CAPTCHA_FONT_PATH = getattr(settings, 'CAPTCHA_FONT_PATH', os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'fonts/Vera.ttf')))

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -1,4 +1,4 @@
-﻿from captcha.conf import settings
+from captcha.conf import settings
 from captcha.models import CaptchaStore
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse, NoReverseMatch


### PR DESCRIPTION
There were leading non-ascii characters in conf/settings.py and fields.py.

I spotted them while parsing their code with ast on python3.5! It was raising a SyntaxError.


> ──────────────
modified: captcha/conf/settings.py
──────────────
@ settings.py:1 @
<U+FEFF>import os
import os
from django.conf import settings

> ───────────────
modified: captcha/fields.py
───────────────
@ fields.py:1 @
<U+FEFF>from captcha.conf import settings
from captcha.conf import settings
from captcha.models import CaptchaStore