### PR TITLE
add autocapitalize, autocorrect, and spellcheck rules for text field

### DIFF
--- a/captcha/templates/captcha/text_field.html
+++ b/captcha/templates/captcha/text_field.html
@@ -1,1 +1,1 @@
-<input autocomplete="off" id="{{id}}_1" name="{{name}}_1" type="text" />
+<input autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" id="{{id}}_1" name="{{name}}_1" type="text" />

--- a/captcha/tests/tests.py
+++ b/captcha/tests/tests.py
@@ -288,12 +288,12 @@ class CaptchaCase(TestCase):
 
     def test_autocomplete_off(self):
         r = self.client.get(reverse('captcha-test'))
-        self.assertTrue('<input autocomplete="off" ' in six.text_type(r.content))
+        self.assertTrue('<input autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" ' in six.text_type(r.content))
 
     def test_autocomplete_not_on_hidden_input(self):
         r = self.client.get(reverse('captcha-test'))
-        self.assertFalse('autocomplete="off" type="hidden" name="captcha_0"' in six.text_type(r.content))
-        self.assertFalse('autocomplete="off" id="id_captcha_0" name="captcha_0" type="hidden"' in six.text_type(r.content))
+        self.assertFalse('autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" type="hidden" name="captcha_0"' in six.text_type(r.content))
+        self.assertFalse('autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" id="id_captcha_0" name="captcha_0" type="hidden"' in six.text_type(r.content))
 
     def test_transparent_background(self):
         __current_test_mode_setting = settings.CAPTCHA_BACKGROUND_COLOR


### PR DESCRIPTION
I was running into problems with mobile phones trying to autocorrect what I was typing in. I figured the autocapitalize and spellcheck rules should go on there, too.

The tests aren't amazing, but I think they do the trick. Let me know if you have issue with what I did.