### PR TITLE
Compatibility with django2a1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     env: TOX_ENV=py36-django110
   - python: "3.6"
     env: TOX_ENV=py36-django111
+  - python: "3.6"
+    env: TOX_ENV=py36-django20
   - python: "2.7"
     env: TOX_ENV=py27-django18
   - python: "2.7"

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -2,7 +2,10 @@ from captcha.conf import settings
 from captcha.models import CaptchaStore
 import django
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse, NoReverseMatch
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse, NoReverseMatch
+else:
+    from django.urls import reverse, NoReverseMatch
 from django.forms import ValidationError
 from django.forms.fields import CharField, MultiValueField
 from django.forms.widgets import TextInput, MultiWidget, HiddenInput

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -2,10 +2,10 @@ from captcha.conf import settings
 from captcha.models import CaptchaStore
 import django
 from django.core.exceptions import ImproperlyConfigured
-if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse, NoReverseMatch
-else:
-    from django.urls import reverse, NoReverseMatch
+if django.VERSION < (1, 10):  # NOQA
+    from django.core.urlresolvers import reverse, NoReverseMatch  # NOQA
+else:  # NOQA
+    from django.urls import reverse, NoReverseMatch  # NOQA
 from django.forms import ValidationError
 from django.forms.fields import CharField, MultiValueField
 from django.forms.widgets import TextInput, MultiWidget, HiddenInput

--- a/captcha/helpers.py
+++ b/captcha/helpers.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 import random
 from captcha.conf import settings
-from django.core.urlresolvers import reverse
+import django
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from six import u, text_type
 
 

--- a/captcha/helpers.py
+++ b/captcha/helpers.py
@@ -2,10 +2,10 @@
 import random
 from captcha.conf import settings
 import django
-if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse
-else:
-    from django.urls import reverse
+if django.VERSION < (1, 10):  # NOQA
+    from django.core.urlresolvers import reverse  # NOQA
+else:  # NOQA
+    from django.urls import reverse  # NOQA
 from six import u, text_type
 
 

--- a/captcha/tests/tests.py
+++ b/captcha/tests/tests.py
@@ -2,9 +2,13 @@
 from captcha.conf import settings
 from captcha.fields import CaptchaField, CaptchaTextInput
 from captcha.models import CaptchaStore
+import django
 from django.core import management
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+if django.VERSION < (1, 10):
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from django.test import TestCase, override_settings
 from django.utils.translation import ugettext_lazy
 from django.utils import timezone

--- a/captcha/tests/tests.py
+++ b/captcha/tests/tests.py
@@ -5,10 +5,10 @@ from captcha.models import CaptchaStore
 import django
 from django.core import management
 from django.core.exceptions import ImproperlyConfigured
-if django.VERSION < (1, 10):
-    from django.core.urlresolvers import reverse
-else:
-    from django.urls import reverse
+if django.VERSION < (1, 10):  # NOQA
+    from django.core.urlresolvers import reverse  # NOQA
+else:  # NOQA
+    from django.urls import reverse  # NOQA
 from django.test import TestCase, override_settings
 from django.utils.translation import ugettext_lazy
 from django.utils import timezone

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
         {py27,py36}-django{18,19,110,111},
+        py36-django20,
         gettext,flake8,docs
 
 skipsdist = True
@@ -19,9 +20,10 @@ deps =
         django19: Django==1.9
         django110: Django==1.10
         django111: Django==1.11
+        django20: Django==2.0a1
 
         py27-django{18,19,110,111}: python-memcached
-        py36-django{18,19,110,111}: python3-memcached
+        py36-django{18,19,110,111,20}: python3-memcached
         Pillow
         six
         south


### PR DESCRIPTION
`from django.core.urlresolvers import …` has been removed.
Now you just have to do `from django.urls import …`

This should be backwards compatible down to 1.8 *crossing fingers*

Edit: Nope it isn't, only works in 1.10+ … I'll add some `if version` stuff later. Don't merge until then.