### PR TITLE
Insert random bytes at the end of the genreated WAV audio files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Version 0.5.6 (unreleased)
 * Updated documentation (Fixes #122, thanks @claudep)
 * Test against Django 2.0b1
 * Return a Ranged Response when returning WAV audio to support Safari (Fixes #123, thanks @po5i)
+* Insert random bytes at the end of the genreated WAV audio files, to avoid rainbow-table attacks (Fixes #124, thanks @appleorange1)
 
 
 Version 0.5.5

--- a/captcha/views.py
+++ b/captcha/views.py
@@ -132,7 +132,11 @@ def captcha_audio(request, key):
             text = ', '.join(list(text))
         path = str(os.path.join(tempfile.gettempdir(), '%s.wav' % key))
         subprocess.call([settings.CAPTCHA_FLITE_PATH, "-t", text, "-o", path])
+
         if os.path.isfile(path):
+            with open(path, 'ab') as outfile:
+                outfile.write(bytearray(random.getrandbits(8) for _ in range(1, random.randint(1, 1024))))
+
             response = RangedFileResponse(request, open(path, 'rb'), content_type='audio/wav')
             response['Content-Disposition'] = 'attachment; filename="{}.wav"'.format(key)
             return response


### PR DESCRIPTION
Mitigates the issue described in #124 by adding randomness to each generated audio file, so that a simple hashing of the file can't be used to build a rainbow table.

Despite the extra bytes, Chrome, Safari and Firefox can play the file just fine.