### PR TITLE
Use widget templates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Version 0.5.7 (unreleased)
 --------------------------
-* Use standard rendering of widgets (Issue #128, PR #133, thanks @ziima)
+* Use templates for rendering of widgets (Issue #128, #134, PR #133, #139, thanks @ziima)
 * Always defined audio context variable  (PR #132, thanks @ziima)
 
 

--- a/captcha/conf/settings.py
+++ b/captcha/conf/settings.py
@@ -1,4 +1,6 @@
 import os
+import warnings
+
 from django.conf import settings
 
 CAPTCHA_FONT_PATH = getattr(settings, 'CAPTCHA_FONT_PATH', os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'fonts/Vera.ttf')))
@@ -22,8 +24,16 @@ CAPTCHA_IMAGE_SIZE = getattr(settings, 'CAPTCHA_IMAGE_SIZE', None)
 CAPTCHA_IMAGE_TEMPLATE = getattr(settings, 'CAPTCHA_IMAGE_TEMPLATE', 'captcha/image.html')
 CAPTCHA_HIDDEN_FIELD_TEMPLATE = getattr(settings, 'CAPTCHA_HIDDEN_FIELD_TEMPLATE', 'captcha/hidden_field.html')
 CAPTCHA_TEXT_FIELD_TEMPLATE = getattr(settings, 'CAPTCHA_TEXT_FIELD_TEMPLATE', 'captcha/text_field.html')
-CAPTCHA_FIELD_TEMPLATE = getattr(settings, 'CAPTCHA_FIELD_TEMPLATE', 'captcha/field.html')
+
+if getattr(settings, 'CAPTCHA_FIELD_TEMPLATE', None):
+    msg = ("CAPTCHA_FIELD_TEMPLATE setting is deprecated in favor of widget's template_name.")
+    warnings.warn(msg, DeprecationWarning)
+CAPTCHA_FIELD_TEMPLATE = getattr(settings, 'CAPTCHA_FIELD_TEMPLATE', None)
+if getattr(settings, 'CAPTCHA_OUTPUT_FORMAT', None):
+    msg = ("CAPTCHA_OUTPUT_FORMAT setting is deprecated in favor of widget's template_name.")
+    warnings.warn(msg, DeprecationWarning)
 CAPTCHA_OUTPUT_FORMAT = getattr(settings, 'CAPTCHA_OUTPUT_FORMAT', None)
+
 CAPTCHA_MATH_CHALLENGE_OPERATOR = getattr(settings, 'CAPTCHA_MATH_CHALLENGE_OPERATOR', '*')
 CAPTCHA_GET_FROM_POOL = getattr(settings, 'CAPTCHA_GET_FROM_POOL', False)
 CAPTCHA_GET_FROM_POOL_TIMEOUT = getattr(settings, 'CAPTCHA_GET_FROM_POOL_TIMEOUT', 5)

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -18,6 +18,20 @@ from django.utils.safestring import mark_safe
 from six import u
 
 
+class CaptchaAnswerInput(TextInput):
+    """Text input for captcha answer."""
+
+    # Use *args and **kwargs because signature changed in Django 1.11
+    def build_attrs(self, *args, **kwargs):
+        """Disable automatic corrections and completions."""
+        attrs = super(CaptchaAnswerInput, self).build_attrs(*args, **kwargs)
+        attrs['autocapitalize'] = 'off'
+        attrs['autocomplete'] = 'off'
+        attrs['autocorrect'] = 'off'
+        attrs['spellcheck'] = 'false'
+        return attrs
+
+
 class BaseCaptchaTextInput(MultiWidget):
     """
     Base class for Captcha widgets
@@ -25,7 +39,7 @@ class BaseCaptchaTextInput(MultiWidget):
     def __init__(self, attrs=None):
         widgets = (
             HiddenInput(attrs),
-            TextInput(attrs),
+            CaptchaAnswerInput(attrs),
         )
         super(BaseCaptchaTextInput, self).__init__(widgets, attrs)
 

--- a/captcha/templates/captcha/widgets/captcha.html
+++ b/captcha/templates/captcha/widgets/captcha.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% spaceless %}
+    {% if audio %}
+        <a title="{% trans "Play CAPTCHA as audio file" %}" href="{{ audio }}">
+    {% endif %}
+    <img src="{{ image }}" alt="captcha" class="captcha" />
+    {% if audio %}</a>{% endif %}
+{% endspaceless %}
+{% include "django/forms/widgets/multiwidget.html" %}

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -161,7 +161,7 @@ Defaults to: ``None``
 
 (Used to default to: ``u'%(image)s %(hidden_field)s %(text_field)s'``)
 
-Note: this settings is deprecated in favor of template-based field rendering, use ``CAPTCHA_FIELD_TEMPLATE`` instead (see the Rendering section below).
+.. warning:: This setting is deprecated in favor of template-based widget rendering (see the Rendering section below).
 
 
 CAPTCHA_TEST_MODE
@@ -194,6 +194,20 @@ Defaults to: 5
 Rendering
 +++++++++
 
+``CaptchaTextInput`` supports the widget rendering using template introduced in Django 1.11.
+To change the output HTML, change the ``template_name`` to a custom template or modify ``get_context`` method to provide further context.
+See https://docs.djangoproject.com/en/dev/ref/forms/renderers/ for description of rendering API.
+Keep in mind that ``CaptchaTextInput`` is a subclass of ``MultiWidget`` whic affects the context, see https://docs.djangoproject.com/en/2.0/ref/forms/widgets/#multiwidget.
+
+.. attention:: To provide backwards compatibility, the old style rendering has priority over the widget templates.
+   If the ``CAPTCHA_FIELD_TEMPLATE`` or ``CAPTCHA_OUTPUT_FORMAT`` settings or ``field_templates`` or ``output_format`` parameter are set, the direct rendering gets higher priority.
+   If widget templates are ignored, make sure you're using Django >= 1.11 and disable these settings and parameters.
+
+Old style rendering
+-------------------
+
+.. warning:: This rendering method is deprecated. Use Django >= 1.11 and widgets templates instead.
+
 A CAPTCHA field is made up of three components:
 
 * The actual image that the end user has to copy from
@@ -212,7 +226,7 @@ As of version 0.4.7 you can control how the individual components are rendered, 
 These templates can be overriden in your own ``templates`` folder, or you can change the actual template names by settings ``CAPTCHA_IMAGE_TEMPLATE``, ``CAPTCHA_TEXT_FIELD_TEMPLATE``, ``CAPTCHA_HIDDEN_FIELD_TEMPLATE`` and ``CAPTCHA_FIELD_TEMPLATE``, respectively.
 
 Context
--------
+~~~~~~~
 
 The following context variables are passed to the three "individual" templates:
 


### PR DESCRIPTION
Fix #134 

Update `CaptchaTextInput` to use templates for widget rendering in Django >= 1.11.

Deprecate `field_template` and `output_format` in the widget and settings.