### PR TITLE
tox: add python 3.8 to version matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
         {py27,py36}-django{18,19,110,111},
-        py36-django{20,21,22,30},
+        py{36,37}-django{20,21,22},
+        py{36,37,38}-django30,
         py36-django22-jinja2,
         gettext,flake8,docs
 
@@ -24,7 +25,7 @@ deps =
         django30: Django>=3.0a1,<=3.0.99
 
         py27-django{18,19,110,111}: python-memcached
-        py36-django{18,19,110,111,20,21,22,30}: python3-memcached
+        py{36,37,38}-django{18,19,110,111,20,21,22,30}: python3-memcached
 extras =
         test
 


### PR DESCRIPTION
add recently released python 3.8 to version matrix