### PR TITLE
tox: remove superfluous basepython statement

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ extras =
 
 # Test latest Python-Django combination with Jinja2 templates
 [testenv:py36-django22-jinja2]
-basepython = python3.6
 setenv =
         DJANGO_SETTINGS_MODULE=jinja2_settings
 deps =


### PR DESCRIPTION
The basepython statement is not required as the correct python version is retrieved from the py36 prefix.