### PR TITLE
Fixing Travis.yml as it was unable to parse on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ sudo: false
 
 matrix:
   include:
+  - python: "3.6"  
     env: TOX_ENV=py36-django22
     dist: xenial
-  - python: "3.6"
+  - python: "3.7"
     env: TOX_ENV=py37-django30
     dist: xenial
-  - python: "3.6"
+  - python: "3.7"
     env: TOX_ENV=py37-django31
     dist: xenial
   - python: "3.6"


### PR DESCRIPTION
Hi All,
As jobs were not running on travis-ci because it was unable to parse on intel architecture. Hence fix been provided in PR and is ready to review & merge. Travis Job ID: https://travis-ci.com/github/kishorkunal-raj/django-simple-captcha/builds/190441163
Please take a look.

Regards
Kishor Kunal Raj