### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ sudo: false
 
 matrix:
   include:
+  - python: "3.6"
     env: TOX_ENV=py36-django22
     dist: xenial
-  - python: "3.6"
+  - python: "3.7"
     env: TOX_ENV=py37-django30
     dist: xenial
-  - python: "3.6"
+  - python: "3.7"
     env: TOX_ENV=py37-django31
     dist: xenial
   - python: "3.6"
@@ -18,9 +19,33 @@ matrix:
     env: TOX_ENV=flake8
   - python: "3.6"
     env: TOX_ENV=gettext
-
+    # Adding jobs for ppc64le architecture
+  - python: "3.6"
+    arch: ppc64le
+    env: TOX_ENV=py36-django22
+    dist: xenial
+  - python: "3.7"
+    arch: ppc64le
+    env: TOX_ENV=py37-django30
+    dist: xenial
+  - python: "3.7"
+    arch: ppc64le
+    env: TOX_ENV=py37-django31
+    dist: xenial
+  - python: "3.6"
+    arch: ppc64le
+    env: TOX_ENV=py36-django22-jinja2
+  - python: "3.6"
+    arch: ppc64le
+    env: TOX_ENV=flake8
+  - python: "3.6"
+    arch: ppc64le
+    env: TOX_ENV=gettext
 install:
   - pip install tox
+
+before_install:
+  - if [[ "${TRAVIS_CPU_ARCH}" == "ppc64le" ]]; then sudo apt-get install gettext; fi
 
 script:
   - tox -e $TOX_ENV


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-simple-captcha/builds/190442874

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj