### PR TITLE
Do not generate different images for the same key

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -48,6 +48,8 @@ def captcha_image(request, key, scale=1):
         # HTTP 410 Gone status so that crawlers don't index these expired urls.
         return HttpResponse(status=410)
 
+    random.seed(key)  # Do not generate different images for the same key
+
     text = store.challenge
 
     if isinstance(settings.CAPTCHA_FONT_PATH, six.string_types):


### PR DESCRIPTION
Hi,

Request to the same image URL was generating a different image each time (due to randomness). Captcha-breaking bots could get lots of images for the same challenge and use them to improve accuracy (e.g. run the algorithm on all images and find the most frequent result).

With this small change, each challenge generates a constant image.