### PR TITLE
Remove warning for django 3.2

### DIFF
--- a/captcha/models.py
+++ b/captcha/models.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 class CaptchaStore(models.Model):
+    id = models.AutoField(primary_key=True)
     challenge = models.CharField(blank=False, max_length=32)
     response = models.CharField(blank=False, max_length=32)
     hashkey = models.CharField(blank=False, max_length=40, unique=True)


### PR DESCRIPTION
Remove this warning with django 3.2.x

WARNINGS:
captcha.CaptchaStore: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.