### PR TITLE
Reset the random seed

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -134,7 +134,7 @@ def captcha_image(request, key, scale=1):
     response = HttpResponse(content_type="image/png")
     response.write(out.read())
     response["Content-length"] = out.tell()
-
+    random.seed()
     return response
 
 


### PR DESCRIPTION
Because the random seed is set and returned in the refresh interface, if used by other services, it may cause the random to be calculated.