### PR TITLE
Remove leftover audio tmpfiles

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -202,6 +202,7 @@ def captcha_audio(request, key):
             response = RangedFileResponse(
                 request, open(path, "rb"), content_type="audio/wav"
             )
+            os.remove(path)
             response["Content-Disposition"] = 'attachment; filename="{}.wav"'.format(
                 key
             )


### PR DESCRIPTION
When generating the audio form of a captha, the resulting audio files are never deleted, thus slowly (?) filling up the tmpdir. They aren't cached or reused either.
This PR fixes that by removing the file after the response gets a file descriptor for it.

Closes #225.