### PR TITLE
Delete leftover temporary audio files

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -199,8 +199,13 @@ def captcha_audio(request, key):
             os.rename(mergedpath, path)
 
         if os.path.isfile(path):
+            # Move the response file to a filelike that will be deleted on close
+            temporary_file = tempfile.TemporaryFile()
+            with open(path,'rb') as file:
+                temporary_file.write(file.read())
+            os.remove(path)
             response = RangedFileResponse(
-                request, open(path, "rb"), content_type="audio/wav"
+                request, temporary_file, content_type="audio/wav"
             )
             response["Content-Disposition"] = 'attachment; filename="{}.wav"'.format(
                 key

--- a/captcha/views.py
+++ b/captcha/views.py
@@ -201,9 +201,11 @@ def captcha_audio(request, key):
         if os.path.isfile(path):
             # Move the response file to a filelike that will be deleted on close
             temporary_file = tempfile.TemporaryFile()
-            with open(path,'rb') as file:
-                temporary_file.write(file.read())
+            with open(path,'rb') as original_file:
+                temporary_file.write(original_file.read())
+            temporary_file.seek(0)
             os.remove(path)
+            
             response = RangedFileResponse(
                 request, temporary_file, content_type="audio/wav"
             )


### PR DESCRIPTION
Audio files created while generating audio captchas are never deleted and accumulate in a temporary directory despite never being reused. This PR adds removal of those audio files. 

Note: Previous proposed fix (#224) seems to not work on Windows. Using TemporaryFile instead of relying on file descriptors should work on both Unix and Windows.

Closes #225 