### PR TITLE
Center characters vertically

### DIFF
--- a/captcha/views.py
+++ b/captcha/views.py
@@ -94,13 +94,14 @@ def captcha_image(request, key, scale=1):
         charimage = charimage.crop(charimage.getbbox())
         maskimage = Image.new("L", size)
 
+        yoffset = (size[1] - charimage.size[1]) // 2
         maskimage.paste(
             charimage,
             (
                 xpos,
-                DISTANCE_FROM_TOP,
+                yoffset,
                 xpos + charimage.size[0],
-                DISTANCE_FROM_TOP + charimage.size[1],
+                charimage.size[1] + yoffset,
             ),
         )
         size = maskimage.size


### PR DESCRIPTION
Currently math challenges look a bit weird because the math operators are smaller than the numbers and everything is aligned at the top of the image.

This change moves all characters to the vertical center, making math challenges a bit nicer to look at.

Before: 
![before](https://github.com/user-attachments/assets/e848a9d1-0963-479e-9517-0ff31088966e)

After:
![after](https://github.com/user-attachments/assets/37546b96-5e74-4a81-ac4f-f93cadc42a5c)
